### PR TITLE
Add a streaming API for VoxCPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+launch.json
+__pycache__
+voxcpm.egg-info

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ By default, when you first run the script, the model will be downloaded automati
 ### 2. Basic Usage
 ```python
 import soundfile as sf
+import numpy as np
 from voxcpm import VoxCPM
 
 model = VoxCPM.from_pretrained("openbmb/VoxCPM-0.5B")
 
+# Non-streaming
 wav = model.generate(
     text="VoxCPM is an innovative end-to-end TTS model from ModelBest, designed to generate highly expressive speech.",
     prompt_wav_path=None,      # optional: path to a prompt speech for voice cloning
@@ -81,6 +83,18 @@ wav = model.generate(
 
 sf.write("output.wav", wav, 16000)
 print("saved: output.wav")
+
+# Streaming
+chunks = []
+for chunk in model.generate_streaming(
+    text = "Streaming text to speech is easy with VoxCPM!",
+    # supports same args as above
+):
+    chunks.append(chunk)
+wav = np.concatenate(chunks)
+
+sf.write("output_streaming.wav", wav, 16000)
+print("saved: output_streaming.wav")
 ```
 
 ### 3. CLI Usage


### PR DESCRIPTION
Hey, thanks for the great work!

This PR addresses #8, #21 by adding a streaming API to the VoxCPM and VoxCPMModel classes.

`model.generate` continues to output a complete audio, while `model.generate_streaming` yields a generator that returns a single 0.08s chunk at every generation step.

To ensure streaming is smooth, the last 3 latents are passed to the audio VAE for context and the last 1280 sample chunk is returned. 3 latents seemed to be the minimum context needed to remove audible artifacts from the streaming audio (I determined this by ear, feel free to adjust if you feel it's not enough)

```python
import numpy as np
import soundfile as sf
from voxcpm import VoxCPM
from transformers.trainer_utils import set_seed

model = VoxCPM.from_pretrained("openbmb/VoxCPM-0.5B")
text = "Streaming text to speech is easy with VoxCPM!"

# Non-streaming
set_seed(42)
final = model.generate(text)
sf.write("output.wav", final, model.tts_model.sample_rate)

# Streaming
set_seed(42)
chunks = []
for chunk in model.generate_streaming(text):
    chunks.append(chunk)
final = np.concatenate(chunks)
sf.write("output_streaming.wav", final, model.tts_model.sample_rate)
```

The two results should be audibly identical!