### PR TITLE
修复lora/ft测试代码处传参错误的内容

### DIFF
--- a/scripts/test_voxcpm_ft_infer.py
+++ b/scripts/test_voxcpm_ft_infer.py
@@ -114,7 +114,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )

--- a/scripts/test_voxcpm_lora_infer.py
+++ b/scripts/test_voxcpm_lora_infer.py
@@ -136,7 +136,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )
@@ -153,7 +153,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )
@@ -170,7 +170,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )
@@ -187,7 +187,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )
@@ -205,7 +205,7 @@ def main():
         prompt_text=prompt_text,
         cfg_value=args.cfg_value,
         inference_timesteps=args.inference_timesteps,
-        max_length=args.max_len,
+        max_len=args.max_len,
         normalize=args.normalize,
         denoise=False,
     )


### PR DESCRIPTION
我在训练后运行代码，发现传入参数错误，给出了更正，貌似voxcpm的python库内容和项目代码有些没有统一的地方。
示例代码给出的是max_length，但实际上core部分使用的是max_len
<img width="440" height="165" alt="image" src="https://github.com/user-attachments/assets/4153f926-ec2d-4b80-92d7-a54c78ccc23b" />
<img width="397" height="203" alt="image" src="https://github.com/user-attachments/assets/14f1d20e-875e-431c-bb87-55088ef56e99" />

