### PR TITLE
Chore: Added comment on how to run VoxCPM on background threads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import soundfile as sf
 import numpy as np
 from voxcpm import VoxCPM
 
-model = VoxCPM.from_pretrained("openbmb/VoxCPM1.5")
+model = VoxCPM.from_pretrained("openbmb/VoxCPM1.5") # Set optimize=False to use VoxCPM on a background thread. Performance on higher end GPU's will stay the same.
 
 # Non-streaming
 wav = model.generate(


### PR DESCRIPTION
Chore: Added comment on how to run VoxCPM on background threads. Background threads broke with v1.5

Issues that reference the bug:
#107 
#97 (gradio)
