### PR TITLE
feat: Add automatic CPU/float32 fallback for macOS and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ python scripts/train_voxcpm_finetune.py \
 
 ## 📚 More Information
 
+### 🍎 macOS Support (Apple Silicon)
+
+To run VoxCPM on macOS (Apple Silicon), we recommend following setup, using `uv`.
+We use `uv` to strictly manage dependencies and avoid version conflicts (like incompatible `torch` and `torchcodec` versions) that can occur with standard `pip`.
+
+You also need to install `ffmpeg` for audio processing:
+
+```bash
+brew install ffmpeg
+```
+
+Then, set up the Python environment:
+
+```bash
+uv sync
+source .venv/bin/activate
+```
+
+VoxCPM will then automatically detect macOS and run in CPU mode with float32 precision to ensure stability.
+
+> Running on CPU might be significantly slower than on GPU (CUDA). This mode is intended for Mac compatibility.
+
 ###  🌟 Community Projects
 We're excited to see the VoxCPM community growing! Here are some amazing projects and features built by our community:
 - **[ComfyUI-VoxCPM](https://github.com/wildminder/ComfyUI-VoxCPM)** A VoxCPM extension for ComfyUI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
-    "torch>=2.5.0",
-    "torchaudio>=2.5.0",
-    "torchcodec",
+    "torch>=2.5.0,<2.6.0; sys_platform == 'darwin'",
+    "torch>=2.5.0; sys_platform != 'darwin'",
+    "torchaudio>=2.5.0,<2.6.0; sys_platform == 'darwin'",
+    "torchaudio>=2.5.0; sys_platform != 'darwin'",
+    "torchcodec==0.2.0; sys_platform == 'darwin'",
+    "torchcodec; sys_platform != 'darwin'",
     "transformers>=4.36.2",
     "einops",
     "gradio<6",

--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -121,6 +121,12 @@ class VoxCPMModel(nn.Module):
                 self.device = "mps"
             else:
                 self.device = "cpu"
+        
+        # [Fix] Force CPU on macOS to avoid MPS issues with bfloat16/complex ops
+        if sys.platform == "darwin":
+            print("Detected macOS environment. Forcing 'cpu' and 'float32' to ensure stability.", file=sys.stderr)
+            self.device = "cpu"
+            self.config.dtype = "float32"
         print(f"Running on device: {self.device}, dtype: {self.config.dtype}", file=sys.stderr)
 
         # Text-Semantic LM


### PR DESCRIPTION
### Mac specific suggestions

Hi! Sharing my experience getting VoxCPM running on my Mac (Apple Silicon). It's an awesome project, but I hit a few bumps with the default setup on macOS.

The main blocker seems to be the MPS (Mac GPU). When running normally, it crashed with:

```
loc("mps_matmul"...): error: incompatible dimensions
LLVM ERROR: Failed to infer result type(s).
```

### What worked for me:

1. **Forcing CPU & float32**: I had to explicitly force the device to `cpu` and change the dtype to `float32` manually in both `voxcpm.py` and the downloaded model's `config.json`. My change should be able to detect mac specifically and not enforce this for CUDA devices.

2. **Installing FFmpeg**: I needed to run `brew install ffmpeg` for `torchaudio`/`torchcodec` to load correctly (pretty standard, but might be worth noting in the readme).

3. **PyTorch & TorchCodec**: I use uv and noticed that edge PyTorch versions (like 2.9.x installed by uv) conflict with `torchcodec`, throwing: `The PyTorch version (2.9.1) is not compatible with this version of TorchCodec`. I had to pin back to stable versions (e.g., 2.5.1). The updated pyproject.toml file specifies these versions that worked for me on mac devices.

Just thought I'd drop this hear in case other Mac users run into the same walls! There might be some performance differences of course.

This might not be the best way, but worked for me. Let me know if you have other suggestions.

Thanks for the great work!