### PR TITLE
Add VoxCPM-RKNN2 project link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ We're excited to see the VoxCPM community growing! Here are some amazing project
 - **[VoxCPM-NanoVLLM](https://github.com/a710128/nanovllm-voxcpm)** NanoVLLM integration for VoxCPM for faster, high-throughput inference on GPU.
 - **[VoxCPM-ONNX](https://github.com/bluryar/VoxCPM-ONNX)** ONNX export for VoxCPM supports faster CPU inference.
 - **[VoxCPMANE](https://github.com/0seba/VoxCPMANE)** VoxCPM TTS with Apple Neural Engine backend server.
+- **[VoxCPM-RKNN2](https://huggingface.co/happyme531/VoxCPM-0.5B-RKNN2)** Inference VoxCPM on Rockchip RK3588 with full RKNPU2 acceleration.
 - **[PR: LoRA finetune web UI (by Ayin1412)](https://github.com/OpenBMB/VoxCPM/pull/100)**
 - **[voxcpm_rs](https://github.com/madushan1000/voxcpm_rs)** A re-implementation of VoxCPM-0.5B in Rust.
 


### PR DESCRIPTION
我做了一个瑞芯微RKNPU2加速的部署版本，已经开源：https://huggingface.co/happyme531/VoxCPM-0.5B-RKNN2 ，希望可以加到原项目readme.