### PR TITLE
fix: use specific exceptions instead of bare except

### DIFF
--- a/lora_ft_webui.py
+++ b/lora_ft_webui.py
@@ -156,7 +156,7 @@ def scan_lora_checkpoints(root_dir="lora", with_info=False):
                         with open(lora_config_file, "r", encoding="utf-8") as f:
                             lora_info = json.load(f)
                         base_model = lora_info.get("base_model", "Unknown")
-                    except:
+                    except (json.JSONDecodeError, OSError):
                         pass
                 checkpoints.append((rel_path, base_model))
             else:

--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -222,7 +222,7 @@ class VoxCPMModel(nn.Module):
                 raise ValueError("VoxCPMModel can only be optimized on CUDA device")
             try:
                 import triton
-            except:
+            except ImportError:
                 raise ValueError("triton is not installed")
             self.base_lm.forward_step = torch.compile(self.base_lm.forward_step, mode="reduce-overhead", fullgraph=True)
             self.residual_lm.forward_step = torch.compile(self.residual_lm.forward_step, mode="reduce-overhead", fullgraph=True)


### PR DESCRIPTION
- `lora_ft_webui.py`: `except (json.JSONDecodeError, OSError):` for LoRA config file parsing
- `voxcpm.py`: `except ImportError:` for triton availability check