### PR TITLE
perf: slice KV cache to actual seq length — 1.9x inference speedup

### DIFF
--- a/src/voxcpm/modules/minicpm4/model.py
+++ b/src/voxcpm/modules/minicpm4/model.py
@@ -196,18 +196,22 @@ class MiniCPMAttention(nn.Module):
         key_cache[:, :, position_id, :] = key_states
         value_cache[:, :, position_id, :] = value_states
 
-        attn_mask = torch.arange(key_cache.size(2), device=key_cache.device) <= position_id
+        # Slice KV cache to actual sequence length instead of attending over the
+        # full static cache (max_length=8192). This avoids wasting compute on
+        # empty positions and allows SDPA to select the flash attention kernel
+        # (which does not support arbitrary attn_mask).
+        seq_end = position_id + 1
+        k_slice = key_cache[:, :, :seq_end, :].contiguous()
+        v_slice = value_cache[:, :, :seq_end, :].contiguous()
 
         # ref: https://github.com/pytorch/pytorch/issues/163597
         # there is a bug in MPS for non-contiguous tensors, so we need to make them contiguous
         query_states = query_states.contiguous()
-        key_cache = key_cache.contiguous()
-        value_cache = value_cache.contiguous()
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
-            key_cache,
-            value_cache,
-            attn_mask=attn_mask,
+            k_slice,
+            v_slice,
+            is_causal=False,  # q_len=1, no causal mask needed
             enable_gqa=True,
         )
 


### PR DESCRIPTION
## Summary

- `MiniCPMAttention.forward_step` attends over the full static KV cache (`max_length=8192`) every decoding step, even when only ~40 positions are filled
- The boolean `attn_mask` also prevents SDPA from selecting the flash attention kernel
- Fix: slice the KV cache to `position_id + 1` and use `is_causal=False` (safe since `q_len=1`)

## Benchmarks

RTX 3060, bf16, `optimize=False`, `inference_timesteps=10`:

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `forward_step` latency | 40.2ms | 8.9ms | **4.5× faster** |
| End-to-end RTFX | 0.41× | 0.78× | **1.9× faster** |
| Component % (LM step) | 64.5% | 29.1% | No longer the bottleneck |

## Correctness

Attention layer cosine similarity between original and patched at positions 20 and 100 (accumulated KV cache, randomized inputs):

```
Position 20:  cosine=0.9999949336  max_abs_diff=9.77e-04
Position 100: cosine=0.9999952316  max_abs_diff=4.88e-04
```

Differences are bf16 rounding only. Generated audio is perceptually identical.

## Test plan

- [x] Cosine similarity test at attention layer level
- [x] End-to-end audio generation (TTS + voice cloning)
- [x] Verified no artifacts introduced vs original code

🤖 Generated with [Claude Code](https://claude.com/claude-code)