### PR TITLE
fix: correct isinstance/strip order in _generate() to prevent AttributeError on non-string input

### DIFF
--- a/src/voxcpm/core.py
+++ b/src/voxcpm/core.py
@@ -200,7 +200,7 @@ class VoxCPM:
             Yields audio chunks for each generation step if ``streaming=True``,
             otherwise yields a single array containing the final audio.
         """
-        if not text.strip() or not isinstance(text, str):
+        if not isinstance(text, str) or not text.strip():
             raise ValueError("target text must be a non-empty string")
 
         if prompt_wav_path is not None:


### PR DESCRIPTION
Closes #228

## Problem

In `src/voxcpm/core.py`, line 203, the input validation guard was:

```python
if not text.strip() or not isinstance(text, str):
```

Because Python evaluates `or` operands left-to-right, `text.strip()` is called **before** the `isinstance` check. If `text` is not a string (e.g., an `int`, `None`, a list, etc.), this raises an `AttributeError` instead of the intended `ValueError`.

**Example:**
```python
model.generate(text=42, ...)
# Before fix: AttributeError: 'int' object has no attribute 'strip'
# After fix:  ValueError: target text must be a non-empty string
```

## Fix

Swap the operand order so the type check short-circuits first:

```python
# Before (buggy)
if not text.strip() or not isinstance(text, str):

# After (correct)
if not isinstance(text, str) or not text.strip():
```

For valid string inputs the behaviour is identical. For non-string inputs, the `isinstance` check now short-circuits immediately and raises the correct `ValueError` with a clear, actionable message.

## Changed Files

- `src/voxcpm/core.py`: one-line fix in `_generate()` input validation
