### PR TITLE
fix: use context manager for config.json in from_local() to prevent file handle leak

### DIFF
--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -848,7 +848,8 @@ class VoxCPMModel(nn.Module):
 
     @classmethod
     def from_local(cls, path: str, optimize: bool = True, training: bool = False, lora_config: LoRAConfig = None):
-        config = VoxCPMConfig.model_validate_json(open(os.path.join(path, "config.json")).read())
+        with open(os.path.join(path, "config.json"), "r", encoding="utf-8") as _cfg_f:
+            config = VoxCPMConfig.model_validate_json(_cfg_f.read())
         tokenizer = LlamaTokenizerFast.from_pretrained(path)
         audio_vae_config = getattr(config, "audio_vae_config", None)
         audio_vae = AudioVAE(config=audio_vae_config) if audio_vae_config else AudioVAE()


### PR DESCRIPTION
## Problem

`VoxCPM.from_local()` opens `config.json` with a bare `open()` call, leaving the file descriptor unclosed.

Closes #235

## Root Cause

```python
# BEFORE
config = VoxCPMConfig.model_validate_json(open(os.path.join(path, "config.json")).read())
```

Issues:
- File handle is never explicitly closed; relies on CPython GC
- Missing `encoding="utf-8"` makes decoding locale-dependent

## Fix

```python
# AFTER
with open(os.path.join(path, "config.json"), "r", encoding="utf-8") as _cfg_f:
    config = VoxCPMConfig.model_validate_json(_cfg_f.read())
```

## Why This Matters

- Prevents `ResourceWarning` in test/debug builds
- Avoids file descriptor exhaustion in long-running inference servers or loops that load multiple models
- Adds explicit UTF-8 encoding for cross-platform correctness (especially Windows)
- Consistent with how other file reads in the codebase are handled