### PR TITLE
fix: close file handles in from_local() config loading

### DIFF
--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -852,7 +852,8 @@ class VoxCPMModel(nn.Module):
         device: str | None = None,
         lora_config: LoRAConfig = None,
     ):
-        config = VoxCPMConfig.model_validate_json(open(os.path.join(path, "config.json")).read())
+        with open(os.path.join(path, "config.json"), "r", encoding="utf-8") as _cfg_f:
+            config = VoxCPMConfig.model_validate_json(_cfg_f.read())
         tokenizer = LlamaTokenizerFast.from_pretrained(path)
         audio_vae_config = getattr(config, "audio_vae_config", None)
         audio_vae = AudioVAE(config=audio_vae_config) if audio_vae_config else AudioVAE()

--- a/src/voxcpm/model/voxcpm2.py
+++ b/src/voxcpm/model/voxcpm2.py
@@ -1103,7 +1103,8 @@ class VoxCPM2Model(nn.Module):
         device: str | None = None,
         lora_config: LoRAConfig = None,
     ):
-        config = VoxCPMConfig.model_validate_json(open(os.path.join(path, "config.json")).read())
+        with open(os.path.join(path, "config.json"), "r", encoding="utf-8") as _cfg_f:
+            config = VoxCPMConfig.model_validate_json(_cfg_f.read())
         tokenizer = LlamaTokenizerFast.from_pretrained(path)
         audio_vae_config = getattr(config, "audio_vae_config", None)
         audio_vae = AudioVAEV2(config=audio_vae_config) if audio_vae_config else AudioVAEV2()


### PR DESCRIPTION
## Summary

- Use context managers (`with` statement) when reading `config.json` in `VoxCPMModel.from_local()` and `VoxCPM2Model.from_local()` to prevent file descriptor leaks
- Add explicit `encoding="utf-8"` to avoid locale-dependent decode errors on Windows and non-UTF-8 systems

Closes #235

## Details

Both `from_local()` methods used a bare `open()` call without closing the file handle:

```python
# Before — file handle never closed
config = VoxCPMConfig.model_validate_json(open(os.path.join(path, "config.json")).read())
```

```python
# After — properly closed via context manager
with open(os.path.join(path, "config.json"), "r", encoding="utf-8") as _cfg_f:
    config = VoxCPMConfig.model_validate_json(_cfg_f.read())
```

The issue also existed in `voxcpm2.py` (same pattern), which is fixed in this PR as well.

## Test plan

- [ ] Verify `VoxCPMModel.from_local()` still loads config correctly
- [ ] Verify `VoxCPM2Model.from_local()` still loads config correctly
- [ ] Confirm no `ResourceWarning` is raised under `python -Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)