### PR TITLE
fix: guard neighbour lookups in replace_blank (IndexError on trailing space)

### DIFF
--- a/src/voxcpm/utils/text_normalize.py
+++ b/src/voxcpm/utils/text_normalize.py
@@ -112,7 +112,18 @@ def replace_blank(text: str):
     out_str = []
     for i, c in enumerate(text):
         if c == " ":
-            if (text[i + 1].isascii() and text[i + 1] != " ") and (text[i - 1].isascii() and text[i - 1] != " "):
+            # Keep a space only when it sits between two ASCII word characters.
+            # Guard the neighbour lookups: a trailing space would make text[i + 1]
+            # raise IndexError, and a leading space would make text[i - 1] wrap
+            # around to the last character. Edge spaces are not between two
+            # words, so they are dropped.
+            if (
+                0 < i < len(text) - 1
+                and text[i + 1].isascii()
+                and text[i + 1] != " "
+                and text[i - 1].isascii()
+                and text[i - 1] != " "
+            ):
                 out_str.append(c)
         else:
             out_str.append(c)

--- a/tests/test_text_normalize.py
+++ b/tests/test_text_normalize.py
@@ -1,0 +1,18 @@
+from voxcpm.utils.text_normalize import replace_blank
+
+
+def test_replace_blank_keeps_interior_ascii_space():
+    assert replace_blank("a b") == "a b"
+
+
+def test_replace_blank_drops_edge_spaces():
+    # A space is only kept between two ASCII word characters. A trailing space
+    # used to raise IndexError (text[i + 1]) and a leading space was wrongly
+    # kept (text[i - 1] wrapping to the last character); both are now dropped.
+    assert replace_blank("hello ") == "hello"
+    assert replace_blank(" hello") == "hello"
+    assert replace_blank("a b ") == "a b"
+
+
+def test_replace_blank_drops_space_adjacent_to_non_ascii():
+    assert replace_blank("中 文") == "中文"


### PR DESCRIPTION
`replace_blank` (`src/voxcpm/utils/text_normalize.py`) crashes on text ending in a space, and mishandles text starting with a space.

```python
for i, c in enumerate(text):
    if c == " ":
        if (text[i + 1].isascii() and text[i + 1] != " ") and (text[i - 1].isascii() and text[i - 1] != " "):
            out_str.append(c)
    else:
        out_str.append(c)
```

The intent is to keep a space only when it sits between two ASCII word characters, but the neighbour lookups aren't bounds-checked:

- A **trailing** space makes `text[i + 1]` raise `IndexError: string index out of range`. `replace_blank("hello ")` crashes. This is reachable from `TextNormalizer.normalize()` for any `zh` text that ends in a space.
- A **leading** space makes `text[i - 1]` read `text[-1]` (the last character), so the decision wraps around and a leading space can be wrongly kept.

Fix: only keep the space at interior positions (`0 < i < len(text) - 1`), so edge spaces are dropped (they aren't between two words) and no out-of-range access happens. Interior spacing (e.g. `"a b"` kept, `"中 文"` → `"中文"`) is unchanged.

Added `tests/test_text_normalize.py` covering trailing/leading/interior spaces and a CJK-adjacent space.

Note: I verified the function's behaviour directly (it's pure string logic), but couldn't run the full test locally because importing the package pulls in torch/torchaudio and a native `torchaudio` lib fails to load on my machine — CI should exercise the added test normally.
