### PR TITLE
fix: correct pyproject.toml license field per PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "voxcpm"
 dynamic = ["version"]
 description = "VoxCPM: Tokenizer-Free TTS for Context-Aware Speech Generation and True-to-Life Voice Cloning"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 authors = [
     {name = "OpenBMB", email = "openbmb@gmail.com"}
 ]


### PR DESCRIPTION
The `project.license` field used a bare string ('Apache-2.0'), which is not a valid form per PEP 621. Modern setuptools (>= 80) rejects this with:

    ValueError: invalid pyproject.toml config: project.license.
    configuration error: project.license must be valid exactly by one
    definition (2 matches found)

This breaks `pip install` from source on macOS / newer toolchains (reported in #233). PEP 621 requires a table with either `text` or `file` key, so use the explicit `{text = ...}` form.

Closes #233