### PR TITLE
docs: add audio.cpp to Ecosystem & Community (EN/ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Full documentation: **[voxcpm.readthedocs.io](https://voxcpm.readthedocs.io/en/l
 | **[Nano-vLLM](https://github.com/a710128/nanovllm-voxcpm)**                 | High-throughput and Fast GPU serving                                                             |
 | **[vLLM-Omni](https://github.com/vllm-project/vllm-omni)**                  | Official vLLM omni-modal serving for VoxCPM2 — PagedAttention, OpenAI-compatible API             |
 | **[VoxCPM.cpp](https://github.com/bluryar/VoxCPM.cpp)**                     | GGML/GGUF: CPU, CUDA, Vulkan inference                                                           |
+| **[audio.cpp](https://github.com/0xShug0/audio.cpp)**                       | ggml-based unified C++ inference framework — CPU/CUDA/Vulkan/Metal, CLI & server, no Python      |
 | **[VoxCPM-ONNX](https://github.com/bluryar/VoxCPM-ONNX)**                   | ONNX export for CPU inference                                                                    |
 | **[VoxCPMANE](https://github.com/0seba/VoxCPMANE)**                         | Apple Neural Engine backend                                                                      |
 | **[voxcpm_rs](https://github.com/madushan1000/voxcpm_rs)**                  | Rust re-implementation                                                                           |

--- a/README_zh.md
+++ b/README_zh.md
@@ -579,6 +579,7 @@ python lora_ft_webui.py   # 然后打开 http://localhost:7860
 | [**Nano-vLLM**](https://github.com/a710128/nanovllm-voxcpm) | 高吞吐快速 GPU 推理引擎 |
 | [**vLLM-Omni**](https://github.com/vllm-project/vllm-omni) | 官方 vLLM 全模态服务（原生支持 VoxCPM2）— PagedAttention、OpenAI 兼容 API |
 | [**VoxCPM.cpp**](https://github.com/bluryar/VoxCPM.cpp) | GGML/GGUF：CPU、CUDA、Vulkan 推理 |
+| [**audio.cpp**](https://github.com/0xShug0/audio.cpp) | 基于 ggml 的统一 C++ 推理框架 — CPU/CUDA/Vulkan/Metal，CLI 与服务端，无需 Python |
 | [**VoxCPM-ONNX**](https://github.com/bluryar/VoxCPM-ONNX) | ONNX 导出，支持 CPU 推理 |
 | [**VoxCPMANE**](https://github.com/0seba/VoxCPMANE) | Apple Neural Engine 后端 |
 | [**voxcpm_rs**](https://github.com/madushan1000/voxcpm_rs) | Rust 重新实现 |


### PR DESCRIPTION
### What

Adds [**audio.cpp**](https://github.com/0xShug0/audio.cpp) to the **Ecosystem & Community** table in both `README.md` and `README_zh.md`, placed next to the existing `VoxCPM.cpp` entry (both are ggml/C++ inference paths).

| Project | Description |
|---|---|
| [**audio.cpp**](https://github.com/0xShug0/audio.cpp) | ggml-based unified C++ inference framework — CPU/CUDA/Vulkan/Metal, CLI & server, no Python |

### Why

Requested by the project author in #354. audio.cpp is a ggml-based C++ inference framework that lists **VoxCPM2-2B (48 kHz)** as a **`released`** supported model. It offers a Python-free, portable native inference path (CLI + server) across CPU/CUDA/Vulkan/Metal backends, complementing the existing `VoxCPM.cpp` and `VoxCPM-ONNX` entries.

The description is kept factual and scoped to what is verifiable from the upstream project; performance numbers are intentionally left out of the README entry.

### Notes

- Community projects are not officially maintained by OpenBMB (per the existing disclaimer in the section).
- Only the two README files are touched; two lines added total.

Closes #354.