### PR TITLE
docs: clarify seed compatibility for PyPI 2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ pip install voxcpm
 
 > **Requirements:** Python ≥ 3.10 (<3.13), PyTorch ≥ 2.5.0, CUDA ≥ 12.0. See [Quick Start Docs](https://voxcpm.readthedocs.io/en/latest/quickstart.html) for details.
 
+> **Compatibility:** The `seed` parameter and CLI option require a release newer than 2.0.3. With `voxcpm==2.0.3`, omit `seed`; until the next release, install from source with `pip install git+https://github.com/OpenBMB/VoxCPM.git`.
+
 ### Python API
 
 #### 🗣️ Text-to-Speech

--- a/README_zh.md
+++ b/README_zh.md
@@ -94,6 +94,8 @@ pip install voxcpm
 
 > **环境要求：** Python ≥ 3.10 (<3.13)，PyTorch ≥ 2.5.0，CUDA ≥ 12.0。详见 [快速开始文档](https://voxcpm.readthedocs.io/zh-cn/latest/quickstart.html)。
 
+> **兼容性：** `seed` 参数和命令行选项需要高于 2.0.3 的版本。使用 `voxcpm==2.0.3` 时请省略 `seed`；新版本发布前，可通过 `pip install git+https://github.com/OpenBMB/VoxCPM.git` 从源码安装。
+
 ### Python API
 
 #### 🗣️ 文本转语音


### PR DESCRIPTION
## Summary

Clarifies in both READMEs that `seed` is unavailable in PyPI 2.0.3 and provides the source-install workaround.

Related to #351; seed support was added in #327.

## Validation

- `git diff --check`
- verified matching English and Chinese notes
