### PR TITLE
Fix prompt mismatch validation and clarify generation completion

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,11 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 import voxcpm
 from voxcpm.model.utils import resolve_runtime_device
+from voxcpm.prompt_validation import (
+    PromptMismatchError,
+    audio_file_sha256,
+    validate_prompt_transcript,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -272,6 +277,17 @@ class VoxCPMDemo:
         )
         return res[0]["text"].split("|>")[-1]
 
+    def prompt_wav_recognition_with_hash(self, prompt_wav: str) -> tuple[str, str]:
+        """Transcribe one immutable audio file and return its text and SHA-256."""
+        before_hash = audio_file_sha256(prompt_wav)
+        text = self.prompt_wav_recognition(prompt_wav).strip()
+        after_hash = audio_file_sha256(prompt_wav)
+        if before_hash != after_hash:
+            raise PromptMismatchError("Reference audio changed while ASR was running; please transcribe it again.")
+        if not text:
+            raise PromptMismatchError("ASR returned an empty transcript; Ultimate Cloning cannot continue safely.")
+        return text, after_hash
+
     def _build_generate_kwargs(
         self,
         *,
@@ -283,6 +299,7 @@ class VoxCPMDemo:
         denoise: bool,
         inference_timesteps: int = 10,
         seed: Optional[int] = None,
+        prompt_validation: str = "error",
     ) -> dict:
         generate_kwargs = dict(
             text=final_text,
@@ -292,6 +309,7 @@ class VoxCPMDemo:
             normalize=do_normalize,
             denoise=denoise,
             seed=seed,
+            prompt_validation=prompt_validation,
         )
         if prompt_text_clean and audio_path:
             generate_kwargs["prompt_wav_path"] = audio_path
@@ -309,6 +327,7 @@ class VoxCPMDemo:
         denoise: bool = True,
         inference_timesteps: int = 10,
         seed: Optional[int] = None,
+        prompt_validation: str = "error",
     ) -> Tuple[int, np.ndarray, Optional[int]]:
         current_model = self.get_or_load_voxcpm()
 
@@ -342,6 +361,7 @@ class VoxCPMDemo:
             denoise=denoise,
             inference_timesteps=inference_timesteps,
             seed=seed,
+            prompt_validation=prompt_validation,
         )
         wav = current_model.generate(**generate_kwargs)
         last_successful_seed = getattr(current_model.tts_model, "last_successful_seed", seed)
@@ -373,6 +393,8 @@ def create_demo_interface(demo: VoxCPMDemo):
         ref_wav: Optional[str],
         use_prompt_text: bool,
         prompt_text_value: str,
+        recognized_audio_hash: Optional[str],
+        recognized_prompt_text: Optional[str],
         cfg_value: float,
         do_normalize: bool,
         denoise: bool,
@@ -382,6 +404,33 @@ def create_demo_interface(demo: VoxCPMDemo):
         actual_prompt_text = prompt_text_value.strip() if use_prompt_text else ""
         actual_control = "" if use_prompt_text else control_instruction
         seed = _coerce_seed(seed_value)
+        verified_audio_hash = recognized_audio_hash
+        verified_prompt_text = recognized_prompt_text
+
+        if use_prompt_text:
+            if not ref_wav:
+                raise gr.Error("Ultimate Cloning requires reference audio.")
+            if not actual_prompt_text:
+                raise gr.Error("Ultimate Cloning requires a non-empty prompt transcript.")
+            try:
+                current_hash = audio_file_sha256(ref_wav)
+                if current_hash != recognized_audio_hash or not recognized_prompt_text:
+                    logger.info("Prompt ASR state is stale or missing; transcribing the current audio again.")
+                    verified_prompt_text, verified_audio_hash = demo.prompt_wav_recognition_with_hash(ref_wav)
+                distance = validate_prompt_transcript(
+                    audio_path=ref_wav,
+                    prompt_text=actual_prompt_text,
+                    recognized_text=verified_prompt_text,
+                    recognized_audio_hash=verified_audio_hash,
+                )
+                logger.info(f"Prompt transcript validation passed (normalized distance={distance:.3f}).")
+            except PromptMismatchError as exc:
+                raise gr.Error(str(exc)) from exc
+            except Exception as exc:
+                raise gr.Error(f"ASR prompt verification failed: {exc}") from exc
+        else:
+            verified_audio_hash = None
+            verified_prompt_text = None
         sr, wav_np, last_successful_seed = demo.generate_tts_audio(
             text_input=text,
             control_instruction=actual_control,
@@ -392,8 +441,9 @@ def create_demo_interface(demo: VoxCPMDemo):
             denoise=denoise,
             inference_timesteps=int(dit_steps),
             seed=seed,
+            prompt_validation="error" if use_prompt_text else "warn",
         )
-        return (sr, wav_np), last_successful_seed
+        return (sr, wav_np), last_successful_seed, verified_audio_hash, verified_prompt_text
 
     def _on_toggle_instant(checked):
         """Instant UI toggle — no ASR, no blocking."""
@@ -408,19 +458,22 @@ def create_demo_interface(demo: VoxCPMDemo):
         )
 
     def _run_asr_if_needed(checked, audio_path):
-        """Run ASR after the UI has updated. Only when toggled ON."""
+        """Transcribe the current audio and bind the result to its SHA-256."""
         if not checked or not audio_path:
-            return gr.update()
+            return gr.update(value=""), None, None
         try:
             logger.info("Running ASR on reference audio...")
-            asr_text = demo.prompt_wav_recognition(audio_path)
+            asr_text, audio_hash = demo.prompt_wav_recognition_with_hash(audio_path)
             logger.info(f"ASR result: {asr_text[:60]}...")
-            return gr.update(value=asr_text)
+            return gr.update(value=asr_text), audio_hash, asr_text
         except Exception as e:
             logger.warning(f"ASR recognition failed: {e}")
-            return gr.update(value="")
+            return gr.update(value=""), None, None
 
     with gr.Blocks() as interface:
+        prompt_audio_hash_state = gr.State(value=None)
+        recognized_prompt_text_state = gr.State(value=None)
+
         gr.HTML(
             '<div class="logo-container">'
             '<img src="/gradio_api/file=assets/voxcpm_logo.png" alt="VoxCPM Logo">'
@@ -518,7 +571,13 @@ def create_demo_interface(demo: VoxCPMDemo):
         ).then(
             fn=_run_asr_if_needed,
             inputs=[show_prompt_text, reference_wav],
-            outputs=[prompt_text],
+            outputs=[prompt_text, prompt_audio_hash_state, recognized_prompt_text_state],
+        )
+
+        reference_wav.change(
+            fn=_run_asr_if_needed,
+            inputs=[show_prompt_text, reference_wav],
+            outputs=[prompt_text, prompt_audio_hash_state, recognized_prompt_text_state],
         )
 
         random_seed.change(
@@ -540,13 +599,15 @@ def create_demo_interface(demo: VoxCPMDemo):
                 reference_wav,
                 show_prompt_text,
                 prompt_text,
+                prompt_audio_hash_state,
+                recognized_prompt_text_state,
                 cfg_value,
                 DoNormalizeText,
                 DoDenoisePromptAudio,
                 dit_steps,
                 seed_value,
             ],
-            outputs=[audio_output, seed_value],
+            outputs=[audio_output, seed_value, prompt_audio_hash_state, recognized_prompt_text_state],
             show_progress=True,
             api_name="generate",
         )

--- a/src/voxcpm/core.py
+++ b/src/voxcpm/core.py
@@ -197,6 +197,7 @@ class VoxCPM:
         retry_badcase_ratio_threshold: float = 6.0,
         streaming: bool = False,
         seed: Optional[int] = None,
+        prompt_validation: str = "error",
     ) -> Generator[np.ndarray, None, None]:
         """Synthesize speech for the given text and return a single waveform.
 
@@ -220,6 +221,8 @@ class VoxCPM:
             retry_badcase_ratio_threshold: Threshold for audio-to-text ratio.
             streaming: Whether to return a generator of audio chunks.
             seed: Optional random seed for reproducibility.
+            prompt_validation: Prompt audio/text length policy: ``"off"``,
+                ``"warn"``, or ``"error"`` (default).
         Returns:
             Generator of numpy.ndarray: 1D waveform array (float32) on CPU.
             Yields audio chunks for each generation step if ``streaming=True``,
@@ -269,11 +272,13 @@ class VoxCPM:
                         prompt_text=prompt_text,
                         prompt_wav_path=actual_prompt_path,
                         reference_wav_path=actual_ref_path,
+                        prompt_validation=prompt_validation,
                     )
                 else:
                     fixed_prompt_cache = self.tts_model.build_prompt_cache(
                         prompt_text=prompt_text,
                         prompt_wav_path=actual_prompt_path,
+                        prompt_validation=prompt_validation,
                     )
             else:
                 fixed_prompt_cache = None

--- a/src/voxcpm/model/utils.py
+++ b/src/voxcpm/model/utils.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import warnings
 from typing import List, Optional
 import torch
 from transformers import PreTrainedTokenizer
@@ -35,6 +37,51 @@ def apply_generation_seed(seed: int) -> None:
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+
+
+def should_retry_badcase(
+    generated_audio_length: int,
+    target_text_length: int,
+    ratio_threshold: float,
+    attempt_number: int,
+    max_attempts: int,
+) -> bool:
+    """Report a bad case and return whether another attempt remains."""
+    if target_text_length < 1:
+        raise ValueError("target text must produce at least one token")
+
+    if generated_audio_length < target_text_length * ratio_threshold:
+        return False
+
+    ratio = generated_audio_length / target_text_length
+    if attempt_number < max_attempts:
+        print(
+            f"  Badcase detected, audio_text_ratio={ratio}; "
+            f"retrying with a new seed ({attempt_number}/{max_attempts})...",
+            file=sys.stderr,
+        )
+        return True
+
+    warnings.warn(
+        f"Badcase persisted after {max_attempts} generation attempt(s) "
+        f"(audio_text_ratio={ratio}). Returning the final attempt; the audio may be truncated, "
+        "repetitive, or inconsistent with the prompt.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    return False
+
+
+def report_generation_completion(generated_steps: int, max_steps: int, stopped_by_model: bool) -> None:
+    """Make normal model-directed early stopping explicit in terminal logs."""
+    if stopped_by_model:
+        message = (
+            f"Generation completed normally: {generated_steps}/{max_steps} steps "
+            "(model stop token predicted)."
+        )
+    else:
+        message = f"Generation completed: {generated_steps}/{max_steps} steps (max_len reached without a stop token)."
+    print(message, file=sys.stderr)
 
 
 def mask_multichar_chinese_tokens(tokenizer: PreTrainedTokenizer):

--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -38,6 +38,7 @@ except ImportError:
 from tqdm import tqdm
 from transformers import LlamaTokenizerFast
 
+from ..prompt_validation import validate_prompt_feature_ratio
 from ..modules.audiovae import AudioVAE, AudioVAEConfig
 from ..modules.layers import ScalarQuantizationLayer
 from ..modules.layers.lora import apply_lora_to_named_linear_modules
@@ -51,7 +52,9 @@ from .utils import (
     mask_multichar_chinese_tokens,
     next_and_close,
     pick_runtime_dtype,
+    report_generation_completion,
     resolve_runtime_device,
+    should_retry_badcase,
 )
 
 
@@ -371,6 +374,7 @@ class VoxCPMModel(nn.Module):
         retry_badcase_ratio_threshold: float = 6.0,  # setting acceptable ratio of audio length to text length (for badcase detection)
         streaming: bool = False,
         seed: Optional[int] = None,
+        prompt_validation: str = "warn",
     ) -> Generator[torch.Tensor, None, None]:
         if retry_badcase and streaming:
             warnings.warn("Retry on bad cases is not supported in streaming mode, setting retry_badcase=False.")
@@ -433,6 +437,11 @@ class VoxCPMModel(nn.Module):
                 self.patch_size,
             ).permute(1, 2, 0)
             audio_length = audio_feat.size(0)
+            validate_prompt_feature_ratio(
+                audio_length,
+                len(self.text_tokenizer(prompt_text)),
+                mode=prompt_validation,
+            )
             text_pad_token = torch.zeros(audio_length, dtype=torch.int32, device=text_token.device)
             text_token = torch.cat([text_token, text_pad_token])
             audio_pad_feat = torch.zeros(
@@ -485,19 +494,17 @@ class VoxCPMModel(nn.Module):
                 break
             else:
                 latent_pred, pred_audio_feat = next_and_close(inference_result)
-                if retry_badcase:
-                    if pred_audio_feat.shape[0] >= target_text_length * retry_badcase_ratio_threshold:
-                        print(
-                            f"  Badcase detected, audio_text_ratio={pred_audio_feat.shape[0] / target_text_length}, retrying...",
-                            file=sys.stderr,
-                        )
-                        retry_badcase_times += 1
-                        current_seed += 1
-                        continue
-                    else:
-                        break
-                else:
-                    break
+                if retry_badcase and should_retry_badcase(
+                    pred_audio_feat.shape[0],
+                    target_text_length,
+                    retry_badcase_ratio_threshold,
+                    retry_badcase_times + 1,
+                    retry_badcase_max_times,
+                ):
+                    retry_badcase_times += 1
+                    current_seed += 1
+                    continue
+                break
 
         if not streaming:
             self.last_successful_seed = last_attempt_seed
@@ -509,6 +516,7 @@ class VoxCPMModel(nn.Module):
         self,
         prompt_text: str,
         prompt_wav_path: str,
+        prompt_validation: str = "warn",
     ):
         """
         Build prompt cache for subsequent fast generation.
@@ -549,6 +557,11 @@ class VoxCPMModel(nn.Module):
         ).permute(
             1, 2, 0
         )  # (D, T, P)
+        validate_prompt_feature_ratio(
+            audio_feat.size(0),
+            len(self.text_tokenizer(prompt_text)),
+            mode=prompt_validation,
+        )
         # build prompt cache - only save raw text and audio features
         prompt_cache = {
             "prompt_text": prompt_text,
@@ -721,19 +734,17 @@ class VoxCPMModel(nn.Module):
                 break
             else:
                 latent_pred, pred_audio_feat = next_and_close(inference_result)
-                if retry_badcase:
-                    if pred_audio_feat.shape[0] >= target_text_length * retry_badcase_ratio_threshold:
-                        print(
-                            f"  Badcase detected, audio_text_ratio={pred_audio_feat.shape[0] / target_text_length}, retrying...",
-                            file=sys.stderr,
-                        )
-                        retry_badcase_times += 1
-                        current_seed += 1
-                        continue
-                    else:
-                        break
-                else:
-                    break
+                if retry_badcase and should_retry_badcase(
+                    pred_audio_feat.shape[0],
+                    target_text_length,
+                    retry_badcase_ratio_threshold,
+                    retry_badcase_times + 1,
+                    retry_badcase_max_times,
+                ):
+                    retry_badcase_times += 1
+                    current_seed += 1
+                    continue
+                break
         if not streaming:
             self.last_successful_seed = last_attempt_seed
             decode_audio = self.audio_vae.decode(latent_pred.to(torch.float32))
@@ -830,7 +841,10 @@ class VoxCPMModel(nn.Module):
         self.residual_lm.kv_cache.fill_caches(residual_kv_cache_tuple)
         residual_hidden = residual_enc_outputs[:, -1, :]
 
-        for i in tqdm(range(max_len)):
+        generated_steps = 0
+        stopped_by_model = False
+        for i in tqdm(range(max_len), desc="Generating audio"):
+            generated_steps = i + 1
             dit_hidden_1 = self.lm_to_dit_proj(lm_hidden)  # [b, h_dit]
             dit_hidden_2 = self.res_to_dit_proj(residual_hidden)  # [b, h_dit]
             dit_hidden = dit_hidden_1 + dit_hidden_2  # [b, h_dit]
@@ -860,6 +874,7 @@ class VoxCPMModel(nn.Module):
 
             stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)[0].cpu().item()
             if i > min_len and stop_flag == 1:
+                stopped_by_model = True
                 break
 
             lm_hidden = self.base_lm.forward_step(
@@ -872,6 +887,7 @@ class VoxCPMModel(nn.Module):
                 torch.tensor([self.residual_lm.kv_cache.step()], device=curr_embed.device),
             ).clone()
 
+        report_generation_completion(generated_steps, max_len, stopped_by_model)
         if not streaming:
             pred_feat_seq = torch.cat(pred_feat_seq, dim=1)  # b, t, p, d
             feat_pred = rearrange(pred_feat_seq, "b t p d -> b d (t p)", b=B, p=self.patch_size)

--- a/src/voxcpm/model/voxcpm2.py
+++ b/src/voxcpm/model/voxcpm2.py
@@ -39,6 +39,7 @@ except ImportError:
 from tqdm import tqdm
 from transformers import LlamaTokenizerFast
 
+from ..prompt_validation import validate_prompt_feature_ratio
 from ..modules.audiovae import AudioVAEV2, AudioVAEConfigV2
 from ..modules.layers import ScalarQuantizationLayer
 from ..modules.layers.lora import apply_lora_to_named_linear_modules
@@ -52,7 +53,9 @@ from .utils import (
     mask_multichar_chinese_tokens,
     next_and_close,
     pick_runtime_dtype,
+    report_generation_completion,
     resolve_runtime_device,
+    should_retry_badcase,
 )
 
 
@@ -482,6 +485,7 @@ class VoxCPM2Model(nn.Module):
         streaming: bool = False,
         streaming_prefix_len: int = 4,
         seed: Optional[int] = None,
+        prompt_validation: str = "warn",
     ) -> Generator[torch.Tensor, None, None]:
         if retry_badcase and streaming:
             warnings.warn("Retry on bad cases is not supported in streaming mode, setting retry_badcase=False.")
@@ -507,6 +511,11 @@ class VoxCPM2Model(nn.Module):
             )
             prompt_feat = self._encode_wav(prompt_wav_path, padding_mode="left", trim_silence_vad=trim_silence_vad)
             prompt_audio_length = prompt_feat.size(0)
+            validate_prompt_feature_ratio(
+                prompt_audio_length,
+                len(self.text_tokenizer(prompt_text)),
+                mode=prompt_validation,
+            )
 
             ref_tokens, ref_feats, ref_t_mask, ref_a_mask = self._make_ref_prefix(ref_feat, text_token.device)
 
@@ -610,6 +619,11 @@ class VoxCPM2Model(nn.Module):
 
             prompt_feat = self._encode_wav(prompt_wav_path, padding_mode="left", trim_silence_vad=trim_silence_vad)
             prompt_audio_length = prompt_feat.size(0)
+            validate_prompt_feature_ratio(
+                prompt_audio_length,
+                len(self.text_tokenizer(prompt_text)),
+                mode=prompt_validation,
+            )
             prompt_pad_token = torch.zeros(prompt_audio_length, dtype=torch.int32, device=text_token.device)
             text_pad_feat = torch.zeros(
                 (text_length, self.patch_size, self.audio_vae.latent_dim),
@@ -667,19 +681,17 @@ class VoxCPM2Model(nn.Module):
                 break
             else:
                 latent_pred, pred_audio_feat, context_len = next_and_close(inference_result)
-                if retry_badcase:
-                    if pred_audio_feat.shape[0] >= target_text_length * retry_badcase_ratio_threshold:
-                        print(
-                            f"  Badcase detected, audio_text_ratio={pred_audio_feat.shape[0] / target_text_length}, retrying...",
-                            file=sys.stderr,
-                        )
-                        retry_badcase_times += 1
-                        current_seed += 1
-                        continue
-                    else:
-                        break
-                else:
-                    break
+                if retry_badcase and should_retry_badcase(
+                    pred_audio_feat.shape[0],
+                    target_text_length,
+                    retry_badcase_ratio_threshold,
+                    retry_badcase_times + 1,
+                    retry_badcase_max_times,
+                ):
+                    retry_badcase_times += 1
+                    current_seed += 1
+                    continue
+                break
 
         if not streaming:
             self.last_successful_seed = last_attempt_seed
@@ -698,6 +710,7 @@ class VoxCPM2Model(nn.Module):
         prompt_wav_path: str = None,
         reference_wav_path: str = None,
         trim_silence_vad: bool = False,
+        prompt_validation: str = "warn",
     ):
         """
         Build prompt cache for subsequent generation.
@@ -735,12 +748,18 @@ class VoxCPM2Model(nn.Module):
             )
 
         if prompt_wav_path and prompt_text is not None:
-            cache["prompt_text"] = prompt_text
-            cache["audio_feat"] = self._encode_wav(
+            prompt_audio_feat = self._encode_wav(
                 prompt_wav_path,
                 padding_mode="left",
                 trim_silence_vad=trim_silence_vad,
             )
+            validate_prompt_feature_ratio(
+                prompt_audio_feat.size(0),
+                len(self.text_tokenizer(prompt_text)),
+                mode=prompt_validation,
+            )
+            cache["prompt_text"] = prompt_text
+            cache["audio_feat"] = prompt_audio_feat
 
         has_ref = "ref_audio_feat" in cache
         has_prompt = "audio_feat" in cache
@@ -963,19 +982,17 @@ class VoxCPM2Model(nn.Module):
                 break
             else:
                 latent_pred, pred_audio_feat, context_len = next_and_close(inference_result)
-                if retry_badcase:
-                    if pred_audio_feat.shape[0] >= target_text_length * retry_badcase_ratio_threshold:
-                        print(
-                            f"  Badcase detected, audio_text_ratio={pred_audio_feat.shape[0] / target_text_length}, retrying...",
-                            file=sys.stderr,
-                        )
-                        retry_badcase_times += 1
-                        current_seed += 1
-                        continue
-                    else:
-                        break
-                else:
-                    break
+                if retry_badcase and should_retry_badcase(
+                    pred_audio_feat.shape[0],
+                    target_text_length,
+                    retry_badcase_ratio_threshold,
+                    retry_badcase_times + 1,
+                    retry_badcase_max_times,
+                ):
+                    retry_badcase_times += 1
+                    current_seed += 1
+                    continue
+                break
         if not streaming:
             self.last_successful_seed = last_attempt_seed
             decode_audio = self.audio_vae.decode(latent_pred.to(torch.float32))
@@ -1080,7 +1097,10 @@ class VoxCPM2Model(nn.Module):
         self.residual_lm.kv_cache.fill_caches(residual_kv_cache_tuple)
         residual_hidden = residual_enc_outputs[:, -1, :]
 
-        for i in tqdm(range(max_len)):
+        generated_steps = 0
+        stopped_by_model = False
+        for i in tqdm(range(max_len), desc="Generating audio"):
+            generated_steps = i + 1
             dit_hidden_1 = self.lm_to_dit_proj(lm_hidden)  # [b, h_dit]
             dit_hidden_2 = self.res_to_dit_proj(residual_hidden)  # [b, h_dit]
             dit_hidden = torch.cat((dit_hidden_1, dit_hidden_2), dim=-1)
@@ -1112,6 +1132,7 @@ class VoxCPM2Model(nn.Module):
 
             stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)[0].cpu().item()
             if i > min_len and stop_flag == 1:
+                stopped_by_model = True
                 break
 
             lm_hidden = self.base_lm.forward_step(
@@ -1124,6 +1145,7 @@ class VoxCPM2Model(nn.Module):
                 curr_residual_input, torch.tensor([self.residual_lm.kv_cache.step()], device=curr_embed.device)
             ).clone()
 
+        report_generation_completion(generated_steps, max_len, stopped_by_model)
         if not streaming:
             pred_feat_seq = torch.cat(pred_feat_seq, dim=1)  # b, t, p, d
             feat_pred = rearrange(pred_feat_seq, "b t p d -> b d (t p)", b=B, p=self.patch_size)

--- a/src/voxcpm/prompt_validation.py
+++ b/src/voxcpm/prompt_validation.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import unicodedata
+import warnings
+
+PROMPT_MIN_FEATURE_TOKEN_RATIO = 0.25
+PROMPT_MAX_FEATURE_TOKEN_RATIO = 8.0
+PROMPT_MAX_NORMALIZED_DISTANCE = 0.35
+_VALID_PROMPT_VALIDATION_MODES = {"off", "warn", "error"}
+
+
+class PromptMismatchError(ValueError):
+    """Raised when prompt audio and its transcript cannot be safely paired."""
+
+
+def audio_file_sha256(path: str, chunk_size: int = 1024 * 1024) -> str:
+    """Return a stable SHA-256 fingerprint for the exact audio file bytes."""
+    if not path or not os.path.isfile(path):
+        raise PromptMismatchError(f"Prompt audio does not exist: {path}")
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as audio_file:
+        for chunk in iter(lambda: audio_file.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_prompt_text(text: str) -> str:
+    """Normalize transcript text for language-agnostic character comparison."""
+    normalized = unicodedata.normalize("NFKC", text or "").casefold()
+    return "".join(char for char in normalized if char.isalnum())
+
+
+def _levenshtein_distance(left: str, right: str) -> int:
+    if len(left) > len(right):
+        left, right = right, left
+    previous = list(range(len(left) + 1))
+    for row, right_char in enumerate(right, start=1):
+        current = [row]
+        for column, left_char in enumerate(left, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[column] + 1,
+                    previous[column - 1] + (left_char != right_char),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def normalized_text_distance(left: str, right: str) -> float:
+    """Return normalized character edit distance in the inclusive range [0, 1]."""
+    left_normalized = normalize_prompt_text(left)
+    right_normalized = normalize_prompt_text(right)
+    if not left_normalized and not right_normalized:
+        return 0.0
+    if not left_normalized or not right_normalized:
+        return 1.0
+    denominator = max(len(left_normalized), len(right_normalized))
+    return _levenshtein_distance(left_normalized, right_normalized) / denominator
+
+
+def validate_prompt_transcript(
+    *,
+    audio_path: str,
+    prompt_text: str,
+    recognized_text: str,
+    recognized_audio_hash: str,
+    max_distance: float = PROMPT_MAX_NORMALIZED_DISTANCE,
+) -> float:
+    """Verify that a transcript belongs to the current audio and matches fresh ASR."""
+    if not 0 <= max_distance <= 1:
+        raise ValueError("max_distance must be between 0 and 1")
+    if not recognized_audio_hash:
+        raise PromptMismatchError("Prompt transcript is not bound to an audio fingerprint; run ASR again.")
+
+    current_audio_hash = audio_file_sha256(audio_path)
+    if current_audio_hash != recognized_audio_hash:
+        raise PromptMismatchError("Reference audio changed after ASR; run transcription again before generation.")
+
+    if not normalize_prompt_text(prompt_text):
+        raise PromptMismatchError("Prompt transcript is empty after normalization.")
+    if not normalize_prompt_text(recognized_text):
+        raise PromptMismatchError("ASR transcript is empty after normalization.")
+
+    distance = normalized_text_distance(prompt_text, recognized_text)
+    if distance > max_distance:
+        raise PromptMismatchError(
+            "Prompt transcript does not match the current audio "
+            f"(normalized edit distance {distance:.3f} > {max_distance:.3f}). "
+            "Run ASR again, correct the transcript, or use reference-only mode."
+        )
+    return distance
+
+
+def validate_prompt_feature_ratio(
+    audio_feature_length: int,
+    text_token_length: int,
+    *,
+    mode: str = "warn",
+    min_ratio: float = PROMPT_MIN_FEATURE_TOKEN_RATIO,
+    max_ratio: float = PROMPT_MAX_FEATURE_TOKEN_RATIO,
+) -> float:
+    """Validate broad prompt audio-feature/text-token length plausibility."""
+    normalized_mode = (mode or "").strip().lower()
+    if normalized_mode not in _VALID_PROMPT_VALIDATION_MODES:
+        raise ValueError(f"prompt_validation must be one of {sorted(_VALID_PROMPT_VALIDATION_MODES)}")
+    if audio_feature_length < 1:
+        raise PromptMismatchError("Prompt audio produced no usable features.")
+    if text_token_length < 1:
+        raise PromptMismatchError("Prompt transcript produced no text tokens.")
+    if min_ratio <= 0 or max_ratio <= min_ratio:
+        raise ValueError("prompt ratio bounds must satisfy 0 < min_ratio < max_ratio")
+
+    ratio = audio_feature_length / text_token_length
+    if normalized_mode == "off" or min_ratio <= ratio <= max_ratio:
+        return ratio
+
+    message = (
+        "Prompt audio/text length mismatch: "
+        f"feature_token_ratio={ratio:.3f}, expected {min_ratio:.3f}..{max_ratio:.3f}. "
+        "Use the exact transcript or switch to reference-only mode."
+    )
+    if normalized_mode == "error":
+        raise PromptMismatchError(message)
+    warnings.warn(message, RuntimeWarning, stacklevel=2)
+    return ratio


### PR DESCRIPTION
## Summary

- Bind the Ultimate Cloning transcript to the exact reference audio with a SHA-256 fingerprint, and rerun ASR whenever the audio changes.
- Reject stale or substantially different transcripts before inference, then add a configurable prompt audio-feature/text-token ratio guard in the public and low-level APIs.
- Make normal model-directed early stopping explicit and stop claiming that another bad-case retry will run after the final attempt.

## Root cause

The Web UI only triggered ASR when Ultimate Cloning was toggled. Replacing the reference audio could therefore leave text recognized from the previous file paired with the new audio. The generation path accepted that pair without validation, so the mismatch surfaced late or produced confusing output rather than an actionable error.

The generation loop also ended normally when the model predicted its stop token, but the terminal only showed an incomplete progress bar. In addition, the final bad-case attempt printed a retry message even though no retry remained.

## Impact

Ultimate Cloning now verifies the audio fingerprint and compares the submitted transcript with fresh ASR before generation. The model layer independently checks broad prompt-length plausibility. Reference-only cloning remains available and does not require a transcript.

The high-level API defaults to strict validation. Low-level model calls default to warnings for compatibility and support `off`, `warn`, and `error` policies.

Addresses #333.
