### PR TITLE
Clarify normal generation completion

### DIFF
--- a/src/voxcpm/model/utils.py
+++ b/src/voxcpm/model/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Optional
 import torch
 from transformers import PreTrainedTokenizer
@@ -35,6 +36,18 @@ def apply_generation_seed(seed: int) -> None:
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+
+
+def report_generation_completion(generated_steps: int, max_steps: int, stopped_by_model: bool) -> None:
+    """Make normal model-directed early stopping explicit in terminal logs."""
+    if stopped_by_model:
+        message = (
+            f"Generation completed normally: {generated_steps}/{max_steps} steps "
+            "(model stop token predicted)."
+        )
+    else:
+        message = f"Generation completed: {generated_steps}/{max_steps} steps (max_len reached without a stop token)."
+    print(message, file=sys.stderr)
 
 
 def mask_multichar_chinese_tokens(tokenizer: PreTrainedTokenizer):

--- a/src/voxcpm/model/voxcpm.py
+++ b/src/voxcpm/model/voxcpm.py
@@ -51,6 +51,7 @@ from .utils import (
     mask_multichar_chinese_tokens,
     next_and_close,
     pick_runtime_dtype,
+    report_generation_completion,
     resolve_runtime_device,
 )
 
@@ -830,7 +831,10 @@ class VoxCPMModel(nn.Module):
         self.residual_lm.kv_cache.fill_caches(residual_kv_cache_tuple)
         residual_hidden = residual_enc_outputs[:, -1, :]
 
-        for i in tqdm(range(max_len)):
+        generated_steps = 0
+        stopped_by_model = False
+        for i in tqdm(range(max_len), desc="Generating audio"):
+            generated_steps = i + 1
             dit_hidden_1 = self.lm_to_dit_proj(lm_hidden)  # [b, h_dit]
             dit_hidden_2 = self.res_to_dit_proj(residual_hidden)  # [b, h_dit]
             dit_hidden = dit_hidden_1 + dit_hidden_2  # [b, h_dit]
@@ -860,6 +864,7 @@ class VoxCPMModel(nn.Module):
 
             stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)[0].cpu().item()
             if i > min_len and stop_flag == 1:
+                stopped_by_model = True
                 break
 
             lm_hidden = self.base_lm.forward_step(
@@ -872,6 +877,7 @@ class VoxCPMModel(nn.Module):
                 torch.tensor([self.residual_lm.kv_cache.step()], device=curr_embed.device),
             ).clone()
 
+        report_generation_completion(generated_steps, max_len, stopped_by_model)
         if not streaming:
             pred_feat_seq = torch.cat(pred_feat_seq, dim=1)  # b, t, p, d
             feat_pred = rearrange(pred_feat_seq, "b t p d -> b d (t p)", b=B, p=self.patch_size)

--- a/src/voxcpm/model/voxcpm2.py
+++ b/src/voxcpm/model/voxcpm2.py
@@ -52,6 +52,7 @@ from .utils import (
     mask_multichar_chinese_tokens,
     next_and_close,
     pick_runtime_dtype,
+    report_generation_completion,
     resolve_runtime_device,
 )
 
@@ -1080,7 +1081,10 @@ class VoxCPM2Model(nn.Module):
         self.residual_lm.kv_cache.fill_caches(residual_kv_cache_tuple)
         residual_hidden = residual_enc_outputs[:, -1, :]
 
-        for i in tqdm(range(max_len)):
+        generated_steps = 0
+        stopped_by_model = False
+        for i in tqdm(range(max_len), desc="Generating audio"):
+            generated_steps = i + 1
             dit_hidden_1 = self.lm_to_dit_proj(lm_hidden)  # [b, h_dit]
             dit_hidden_2 = self.res_to_dit_proj(residual_hidden)  # [b, h_dit]
             dit_hidden = torch.cat((dit_hidden_1, dit_hidden_2), dim=-1)
@@ -1112,6 +1116,7 @@ class VoxCPM2Model(nn.Module):
 
             stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)[0].cpu().item()
             if i > min_len and stop_flag == 1:
+                stopped_by_model = True
                 break
 
             lm_hidden = self.base_lm.forward_step(
@@ -1124,6 +1129,7 @@ class VoxCPM2Model(nn.Module):
                 curr_residual_input, torch.tensor([self.residual_lm.kv_cache.step()], device=curr_embed.device)
             ).clone()
 
+        report_generation_completion(generated_steps, max_len, stopped_by_model)
         if not streaming:
             pred_feat_seq = torch.cat(pred_feat_seq, dim=1)  # b, t, p, d
             feat_pred = rearrange(pred_feat_seq, "b t p d -> b d (t p)", b=B, p=self.patch_size)


### PR DESCRIPTION
## Summary

- Label the generation progress bar explicitly.
- Report whether generation ended because the model predicted its stop token or because `max_len` was reached.
- Apply the same display-only behavior to both VoxCPM model versions.

## Root cause

`tqdm` uses `max_len` as its total, while the model is allowed to stop earlier after predicting its normal stop token. The resulting partial progress bar had no completion explanation, so a successful inference looked like an unexplained interruption.

## Impact

Generation behavior and stop conditions are unchanged. The terminal now prints the actual generated step count and the reason the loop ended.

## Validation

- Exercised both completion messages directly: model stop token and `max_len` exhaustion.
- Parsed all three changed Python files successfully.
- `git diff --check` passed.
- The same completion path previously completed a real GPU generation regression successfully.

Fixes #333.