### PR TITLE
feat: HuggingFace Hub auto-download and sample rate defaults

### DIFF
--- a/lora_ft_webui.py
+++ b/lora_ft_webui.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(project_root / "src"))
 # Default pretrained model path: prefer VoxCPM2 if it exists, fallback to VoxCPM1.5
 _v2_path = project_root / "models" / "openbmb__VoxCPM2"
 _v15_path = project_root / "models" / "openbmb__VoxCPM1.5"
-default_pretrained_path = str(_v2_path if _v2_path.exists() else _v15_path)
+default_pretrained_path = str(_v2_path) if _v2_path.exists() else (str(_v15_path) if _v15_path.exists() else "openbmb/VoxCPM2")
 
 from voxcpm.core import VoxCPM
 from voxcpm.model.voxcpm import LoRAConfig
@@ -99,6 +99,17 @@ training_log = ""
 
 def get_timestamp_str():
     return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def _resolve_pretrained_path(path_or_id: str) -> str:
+    """Resolve model path: use local dir if exists, otherwise download from HuggingFace Hub."""
+    if Path(path_or_id).exists():
+        return path_or_id
+    if "/" in path_or_id and not path_or_id.startswith(("/", ".", "~")):
+        from huggingface_hub import snapshot_download
+        print(f"📥 Downloading model from HuggingFace Hub: {path_or_id}", flush=True)
+        return snapshot_download(path_or_id)
+    return path_or_id
 
 
 def detect_sample_rate(pretrained_path: str) -> Optional[int]:
@@ -391,7 +402,7 @@ def start_training(
     weight_decay=0.01,
     warmup_steps=100,
     max_steps=None,
-    sample_rate=44100,
+    sample_rate=16000,
     max_grad_norm=1.0,
     # LoRA advanced
     enable_lm=True,
@@ -419,6 +430,9 @@ def start_training(
 
     os.makedirs(checkpoints_dir, exist_ok=True)
     os.makedirs(logs_dir, exist_ok=True)
+
+    # Resolve HuggingFace Hub IDs to local paths before reading config
+    pretrained_path = _resolve_pretrained_path(pretrained_path)
 
     # Auto-detect sample_rate from model config.json to prevent mismatch
     detected_sr = detect_sample_rate(pretrained_path)
@@ -971,7 +985,7 @@ with gr.Blocks(title="VoxCPM LoRA WebUI", theme=gr.themes.Soft(), css=custom_css
                             warmup_steps = gr.Number(label="warmup_steps", value=100, precision=0)
                         with gr.Row():
                             max_steps = gr.Number(label="最大步数 (max_steps, 0→默认num_iters)", value=0, precision=0)
-                            sample_rate = gr.Number(label="采样率 (sample_rate)", value=44100, precision=0)
+                            sample_rate = gr.Number(label="采样率 (sample_rate)", value=16000, precision=0)
                             max_grad_norm = gr.Number(label="梯度裁剪 (max_grad_norm, 0=关闭)", value=1.0)
                         with gr.Row():
                             tensorboard_path = gr.Textbox(label="Tensorboard 路径 (可选)", value="")

--- a/lora_ft_webui.py
+++ b/lora_ft_webui.py
@@ -19,7 +19,7 @@ _v2_path = project_root / "models" / "openbmb__VoxCPM2"
 _v15_path = project_root / "models" / "openbmb__VoxCPM1.5"
 default_pretrained_path = str(_v2_path) if _v2_path.exists() else (str(_v15_path) if _v15_path.exists() else "openbmb/VoxCPM2")
 
-from voxcpm.core import VoxCPM
+from voxcpm.core import VoxCPM, resolve_model_path
 from voxcpm.model.voxcpm import LoRAConfig
 import numpy as np
 from funasr import AutoModel
@@ -99,17 +99,6 @@ training_log = ""
 
 def get_timestamp_str():
     return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-
-
-def _resolve_pretrained_path(path_or_id: str) -> str:
-    """Resolve model path: use local dir if exists, otherwise download from HuggingFace Hub."""
-    if Path(path_or_id).exists():
-        return path_or_id
-    if "/" in path_or_id and not path_or_id.startswith(("/", ".", "~")):
-        from huggingface_hub import snapshot_download
-        print(f"📥 Downloading model from HuggingFace Hub: {path_or_id}", flush=True)
-        return snapshot_download(path_or_id)
-    return path_or_id
 
 
 def detect_sample_rate(pretrained_path: str) -> Optional[int]:
@@ -432,7 +421,7 @@ def start_training(
     os.makedirs(logs_dir, exist_ok=True)
 
     # Resolve HuggingFace Hub IDs to local paths before reading config
-    pretrained_path = _resolve_pretrained_path(pretrained_path)
+    pretrained_path = resolve_model_path(pretrained_path)
 
     # Auto-detect sample_rate from model config.json to prevent mismatch
     detected_sr = detect_sample_rate(pretrained_path)

--- a/scripts/train_voxcpm_finetune.py
+++ b/scripts/train_voxcpm_finetune.py
@@ -90,6 +90,12 @@ def train(
     writer = SummaryWriter(log_dir=str(tb_dir)) if accelerator.rank == 0 else None
     tracker = TrainingTracker(writer=writer, log_file=str(save_dir / "train.log"), rank=accelerator.rank)
 
+    # Resolve HuggingFace Hub IDs to local paths (e.g. "openbmb/VoxCPM1.5")
+    if not os.path.isdir(pretrained_path):
+        from huggingface_hub import snapshot_download
+        print(f"Resolving model from HuggingFace Hub: {pretrained_path}", flush=True)
+        pretrained_path = snapshot_download(repo_id=pretrained_path)
+
     # Auto-detect model architecture from config.json
     with open(os.path.join(pretrained_path, "config.json"), "r", encoding="utf-8") as _f:
         _arch = json.load(_f).get("architecture", "voxcpm").lower()

--- a/src/voxcpm/__init__.py
+++ b/src/voxcpm/__init__.py
@@ -1,5 +1,6 @@
-from .core import VoxCPM
+from .core import VoxCPM, resolve_model_path
 
 __all__ = [
     "VoxCPM",
+    "resolve_model_path",
 ]

--- a/src/voxcpm/core.py
+++ b/src/voxcpm/core.py
@@ -11,6 +11,36 @@ from .model.voxcpm2 import VoxCPM2Model
 from .model.utils import next_and_close
 
 
+def resolve_model_path(
+    path_or_id: str,
+    cache_dir: str | None = None,
+    local_files_only: bool = False,
+) -> str:
+    """Resolve a model path: return as-is if it's a local directory,
+    otherwise download from HuggingFace Hub via ``snapshot_download()``.
+
+    This is the single shared helper used by both
+    :meth:`VoxCPM.from_pretrained` (inference) and the training WebUI.
+
+    Args:
+        path_or_id: Local directory path **or** HuggingFace Hub repo ID
+            (e.g. ``"openbmb/VoxCPM2"``).
+        cache_dir: Optional cache directory forwarded to
+            ``snapshot_download()``.
+        local_files_only: When *True*, never attempt a network download.
+
+    Returns:
+        Absolute local filesystem path to the model directory.
+    """
+    if os.path.isdir(path_or_id):
+        return path_or_id
+    return snapshot_download(
+        repo_id=path_or_id,
+        cache_dir=cache_dir,
+        local_files_only=local_files_only,
+    )
+
+
 class VoxCPM:
     def __init__(
         self,
@@ -148,20 +178,14 @@ class VoxCPM:
             ValueError: If neither a valid ``hf_model_id`` nor a resolvable
                 ``hf_model_id`` is provided.
         """
-        repo_id = hf_model_id
-        if not repo_id:
+        if not hf_model_id:
             raise ValueError("You must provide hf_model_id")
 
-        # Load from local path if provided
-        if os.path.isdir(repo_id):
-            local_path = repo_id
-        else:
-            # Otherwise, try from_pretrained (Hub); exit on failure
-            local_path = snapshot_download(
-                repo_id=repo_id,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-            )
+        local_path = resolve_model_path(
+            hf_model_id,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+        )
 
         return cls(
             voxcpm_model_path=local_path,


### PR DESCRIPTION
Fixes #375

Add snapshot_download() resolution for pretrained_path so users can specify a HF model ID (e.g., 'openbmb/VoxCPM2') directly.

Changes:
- Default pretrained_path falls back to Hub ID when no local dirs exist
- _resolve_pretrained_path() helper downloads from Hub on first use
- Training and inference resolve path before reading config.json
- Default sample_rate corrected to 16000 (matches AudioVAE expectation)

Enables zero-setup usage: the WebUI auto-downloads the model on first run.